### PR TITLE
New Font: Inter

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,7 +38,8 @@
             "backgroundColor": "#000000"
           }
         }
-      ]
+      ],
+      "expo-font"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,23 +1,52 @@
-import { Stack } from 'expo-router';
-import React from 'react';
+import {
+  Inter_400Regular,
+  Inter_400Regular_Italic,
+  Inter_700Bold,
+  Inter_700Bold_Italic,
+  Inter_900Black,
+  useFonts,
+} from "@expo-google-fonts/inter";
+import { Stack } from "expo-router";
+import * as SplashScreen from "expo-splash-screen";
+import React, { useEffect } from "react";
+
+SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
+  const [loaded, error] = useFonts({
+    Inter_400Regular,
+    Inter_400Regular_Italic,
+    Inter_700Bold,
+    Inter_700Bold_Italic,
+    Inter_900Black,
+  });
+
+  useEffect(() => {
+    if (loaded || error) {
+      SplashScreen.hideAsync();
+    }
+  }, [loaded, error]);
+
+  if (!loaded && !error) {
+    return null;
+  }
 
   return (
     <Stack
       screenOptions={{
         headerShown: false,
-      }}>
+      }}
+    >
       <Stack.Screen
         name="rsvp"
         options={{
-          title: 'RSVP',
+          title: "RSVP",
         }}
       />
       <Stack.Screen
         name="login"
         options={{
-          title: 'Login',
+          title: "Login",
         }}
       />
     </Stack>

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "weshare",
       "dependencies": {
+        "@expo-google-fonts/inter": "^0.4.2",
         "@expo/vector-icons": "^15.0.2",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
@@ -254,6 +255,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.5", "", { "dependencies": { "@eslint/core": "^0.15.2", "levn": "^0.4.1" } }, "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w=="],
+
+    "@expo-google-fonts/inter": ["@expo-google-fonts/inter@0.4.2", "", {}, "sha512-syfiImMaDmq7cFi0of+waE2M4uSCyd16zgyWxdPOY7fN2VBmSLKEzkfbZgeOjJq61kSqPBNNtXjggiQiSD6gMQ=="],
 
     "@expo/cli": ["@expo/cli@54.0.6", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.8", "@expo/code-signing-certificates": "^0.0.5", "@expo/config": "~12.0.9", "@expo/config-plugins": "~54.0.1", "@expo/devcert": "^1.1.2", "@expo/env": "~2.0.7", "@expo/image-utils": "^0.8.7", "@expo/json-file": "^10.0.7", "@expo/mcp-tunnel": "~0.0.7", "@expo/metro": "~0.1.1", "@expo/metro-config": "~54.0.3", "@expo/osascript": "^2.3.7", "@expo/package-manager": "^1.9.8", "@expo/plist": "^0.4.7", "@expo/prebuild-config": "^54.0.3", "@expo/schema-utils": "^0.1.7", "@expo/server": "^0.7.4", "@expo/spawn-async": "^1.7.2", "@expo/ws-tunnel": "^1.0.1", "@expo/xcpretty": "^4.3.0", "@react-native/dev-middleware": "0.81.4", "@urql/core": "^5.0.6", "@urql/exchange-retry": "^1.3.0", "accepts": "^1.3.8", "arg": "^5.0.2", "better-opn": "~3.0.2", "bplist-creator": "0.1.0", "bplist-parser": "^0.3.1", "chalk": "^4.0.0", "ci-info": "^3.3.0", "compression": "^1.7.4", "connect": "^3.7.0", "debug": "^4.3.4", "env-editor": "^0.4.1", "freeport-async": "^2.0.0", "getenv": "^2.0.0", "glob": "^10.4.2", "lan-network": "^0.1.6", "minimatch": "^9.0.0", "node-forge": "^1.3.1", "npm-package-arg": "^11.0.0", "ora": "^3.4.0", "picomatch": "^3.0.1", "pretty-bytes": "^5.6.0", "pretty-format": "^29.7.0", "progress": "^2.0.3", "prompts": "^2.3.2", "qrcode-terminal": "0.11.0", "require-from-string": "^2.0.2", "requireg": "^0.2.2", "resolve": "^1.22.2", "resolve-from": "^5.0.0", "resolve.exports": "^2.0.3", "semver": "^7.6.0", "send": "^0.19.0", "slugify": "^1.3.4", "source-map-support": "~0.5.21", "stacktrace-parser": "^0.1.10", "structured-headers": "^0.4.1", "tar": "^7.4.3", "terminal-link": "^2.1.1", "undici": "^6.18.2", "wrap-ansi": "^7.0.0", "ws": "^8.12.1" }, "peerDependencies": { "expo": "*", "expo-router": "*", "react-native": "*" }, "optionalPeers": ["expo-router", "react-native"], "bin": { "expo-internal": "build/bin/cli" } }, "sha512-BgxJshNqSODb4Rq4q4lHLBVWVL4683Q+PSJ2fd+m3D5Jqd8nu9zGvcq6I/H8AXV/Ux31eIuUgAojPCjW8LRyZA=="],
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
+    "@expo-google-fonts/inter": "^0.4.2",
     "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
@@ -31,11 +32,11 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",


### PR DESCRIPTION
Installed our desired font (Inter) for use across the codebase. 

## Usage

```ts
// someComponent.tsx

// 1. set the fontFamily prop to the desired font weight in a style object
const styles = StyleSheet.create({
  someName: {
    fontFamily: "Inter_400Regular" // specify font weight as desired
  }
})

// 2. apply the style to some Component, e.g. View (full syntax omitted for clarity)
<View style={styles.someName} />
```

Currently supported font weights are listed below. Preview on [Google Fonts](https://fonts.google.com/specimen/Inter).

```
Inter_400Regular
Inter_400Regular_Italic
Inter_700Bold
Inter_700Bold_Italic
Inter_900Black
```

## Add a new font weight

I only added in a few font weights at the moment, but we have access to all the font weights listed on Google Fonts, e.g. this is what my IDE suggests. 

<img width="432" height="217" alt="image" src="https://github.com/user-attachments/assets/e213c439-1936-4f04-a108-672853318ff8" />

To add a new weight (for any reason), simply add the desired font weight's name into the `useFonts` call in [`app/_layout.tsx`](https://github.com/kohrachel/weshare/blob/f1f5442d6b27d555fb6817f2bfacf25fd74ffdbc/app/_layout.tsx): 

```ts
export default function RootLayout() {
  const [loaded, error] = useFonts({
    // existing weights
    Inter_{weight}{weightDescription} // e.g. Inter_500Medium
  });
  ...
}
```

## Additional Information

This uses the `useFonts` hook from `expo` in `app/_layout.tsx` to load in the fonts. Refer to the official Expo [docs](https://docs.expo.dev/develop/user-interface/fonts/#with-usefonts-hook-1) for more information.

In the (unlikely) event that this approach fails, there are other approaches documented on the website that will allow for importing new/custom fonts. 