### PR TITLE
fix(Component: Button) sync UI across iOS and Android

### DIFF
--- a/components/button-green.tsx
+++ b/components/button-green.tsx
@@ -1,5 +1,4 @@
-import { Button } from 'react-native';
-
+import { StyleSheet, Text, TouchableOpacity } from "react-native";
 interface ButtonGreenProps {
   title: string;
   onPress: () => void;
@@ -7,10 +6,24 @@ interface ButtonGreenProps {
 
 export function ButtonGreen({ title, onPress }: ButtonGreenProps) {
   return (
-    <Button
-        title={title}
-        color="#529053"
-        onPress={onPress}
-    />
+    <TouchableOpacity style={styles.buttonContainer} onPress={onPress}>
+      <Text style={styles.buttonText}>{title}</Text>
+    </TouchableOpacity>
   );
 }
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    alignItems: "center",
+    backgroundColor: "#529053",
+    borderRadius: 10,
+    marginHorizontal: 10,
+    padding: 15,
+    width: "100%",
+  },
+  buttonText: {
+    color: "white",
+    fontSize: 20,
+    fontFamily: "Inter_700Bold",
+  },
+});


### PR DESCRIPTION
> [!WARNING]
> This component is untested on Android, this PR will not be merged until we can verify that this solution works (better) than what we currently have (green text on transparent background), or at least does not break on Android

# Problem: 

We want similar UI in both Android and iOS devices for our `Button` components. 

Using `<Button>` in React Native does not offer a way to set the background color and text color of the button object and its text. There is a `color` prop, but this sets the BACKGROUND color in Android but the TEXT color in iOS.

<img width="833" height="265" alt="image" src="https://github.com/user-attachments/assets/667ddcb7-62b8-4987-aaa2-723dce2e12c7" />

# Solution: 

Use a `<TouchableOpacity>` wrapper to set the background color (and style) and then nest a `<Text>` component within it for styling the button text. 

Solution from [stackoverflow](https://stackoverflow.com/questions/44798426/how-to-change-background-color-of-react-native-button)

@23reide Can you test on Android to see if this actually works? Or if you have a better idea for how to implement this please let me know :) 