### PR TITLE
Fix Ride Creator name stuck on "Loading..." in <SingleRidePost />

### DIFF
--- a/components/SingleRidePost.tsx
+++ b/components/SingleRidePost.tsx
@@ -65,7 +65,10 @@ export default function SingleRidePost({ rideId }: SingleRidePostProps) {
   }, [rideData?.creator]);
 
   useEffect(() => {
-    fetchCreatorInfo().then((name) => setRideCreator(name || "Loading..."));
+    fetchCreatorInfo().then((name) => {
+      if (!name) return;
+      setRideCreator(name);
+    });
   }, [fetchCreatorInfo]);
 
   useEffect(() => {


### PR DESCRIPTION
<img width="758" height="844" alt="image" src="https://github.com/user-attachments/assets/9a205e6c-43dc-4faf-9d03-f45f5e6db408" />

For some reason the `fetchCreatorInfo()` function is invoked at least 3 times. The first and last times the `rideCreator` is null, which causes `setRideCreator("Loading...")` resulting in the UI we see. 

The band aid solution is to return early out of the function if `fetchCreatorInfo()` does not return anything. This ensures that the `rideCreator` is set to the correct name and will not get accidentally overridden. 

There's probably a better solution that involves tracing the dependencies of the `useEffect`/`useCallback` hooks in the code but for our purposes this works. 