### PR TITLE
Workflow to automate test runs

### DIFF
--- a/.github/workflows/run-jest-tests.yml
+++ b/.github/workflows/run-jest-tests.yml
@@ -12,33 +12,27 @@ jobs:
 
     permissions:
       contents: read
-      checks: write
       pull-requests: write
+      checks: write
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: oven-sh/setup-bun@v1
 
-      - name: Install dependencies
-        run: bun install
+      - run: bun install
 
-      - name: Run Jest with coverage
-        run: bun test --coverage --ci
+      - name: Run Jest
+        run: bun test --coverage --ci --json --outputFile=jest-results.json
 
-      - name: Upload full HTML coverage report
+      - name: Upload Jest test report to GitHub
+        uses: dorny/test-reporter@v1
+        with:
+          name: Jest Tests
+          path: jest-results.json
+          reporter: jest-json
+
+      - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-html
-          path: coverage/lcov-report
-
-      - name: Upload lcov.info for PR summary
-        uses: actions/upload-artifact@v4
-        with:
-          name: lcov
-          path: coverage/lcov.info
-
-      - name: Convert coverage to summary text
-        run: |
-          echo "## Coverage Summary" >> $GITHUB_STEP_SUMMARY
-          bunx jest --coverage --coverageReporters=text-summary >> $GITHUB_STEP_SUMMARY
+          name: coverage
+          path: coverage/


### PR DESCRIPTION
This github workflow should automatically run and show Jest tests for every PR so I don't have to go manually run them when reviewing a pr. It won't block anything, but could be configured to block a merge if coverage is below a certain point.